### PR TITLE
update sources debounced via updateDebounce flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "earcut": "^2.2.3",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.4.3",
+        "lodash": "^4.17.21",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.2",
@@ -12914,8 +12915,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -29385,8 +29385,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "access": "public"
   },
   "dependencies": {
+    "@globalfishingwatch/fourwings-aggregate": "4.2.0",
     "@mapbox/geojson-rewind": "^0.5.1",
     "@mapbox/jsonlint-lines-primitives": "^2.0.2",
     "@mapbox/mapbox-gl-supported": "^2.0.1",
     "@mapbox/point-geometry": "^0.1.0",
-    "@globalfishingwatch/fourwings-aggregate": "4.2.0",
     "@mapbox/tilebelt": "^1.0.2",
     "@mapbox/tiny-sdf": "^2.0.4",
     "@mapbox/unitbezier": "^0.0.1",
@@ -33,6 +33,7 @@
     "earcut": "^2.2.3",
     "geojson-vt": "^3.2.1",
     "gl-matrix": "^3.4.3",
+    "lodash": "^4.17.21",
     "murmurhash-js": "^1.0.0",
     "pbf": "^3.2.1",
     "potpack": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@globalfishingwatch/maplibre-gl",
   "description": "BSD licensed community fork of mapbox-gl, a WebGL interactive maps library",
-  "version": "2.1.9-gfw.19",
+  "version": "2.1.9-gfw.20",
   "main": "dist/maplibre-gl.js",
   "style": "dist/maplibre-gl.css",
   "license": "BSD-3-Clause",

--- a/src/source/source_cache.ts
+++ b/src/source/source_cache.ts
@@ -20,7 +20,7 @@ import type Dispatcher from '../util/dispatcher';
 import type Transform from '../geo/transform';
 import type {TileState} from './tile';
 import type {Callback} from '../types/callback';
-import type {SourceSpecification} from '../style-spec/types.g';
+import type {SourceSpecification, TemporalgridSourceSpecification} from '../style-spec/types.g';
 
 /**
  * `SourceCache` is responsible for
@@ -53,6 +53,7 @@ class SourceCache extends Evented {
     };
     _maxTileCacheSize: number;
     _paused: boolean;
+    _updateDebounce: boolean;
     _shouldReloadOnResume: boolean;
     _coveredTiles: {[_: string]: boolean};
     transform: Transform;
@@ -94,7 +95,7 @@ class SourceCache extends Evented {
         });
 
         this._source = createSource(id, options, dispatcher, this);
-
+        this._updateDebounce = (options as TemporalgridSourceSpecification).updateDebounce || false;
         this._tiles = {};
         this._cache = new TileCache(0, this._unloadTile.bind(this));
         this._timers = {};

--- a/src/style/style.ts
+++ b/src/style/style.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import debounce from 'lodash/debounce';
 
 import {Event, ErrorEvent, Evented} from '../util/evented';
 import StyleLayer from './style_layer';
@@ -1259,9 +1260,20 @@ class Style extends Evented {
         this.sourceCaches[id].reload();
     }
 
+    _debouncedUpdateSource = debounce(
+        (id: string, transform: Transform) => {
+            this.sourceCaches[id].update(transform);
+        },
+        60
+    );
+
     _updateSources(transform: Transform) {
         for (const id in this.sourceCaches) {
-            this.sourceCaches[id].update(transform);
+            if (this.sourceCaches[id]._updateDebounce) {
+                this._debouncedUpdateSource(id, transform);
+            } else {
+                this.sourceCaches[id].update(transform);
+            }
         }
     }
 


### PR DESCRIPTION
Use `updateDebounce` in your source specification to add a 60ms debounced time and avoid requesting lots of requests while zooming